### PR TITLE
Let's inject node.js inside vite config - the best way to do this

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,17 +46,6 @@
   <body>
     <noscript>Please, turn on JavaScript to see this page.</noscript>
     <div id="root"></div>
-    <!-- Define to use the web3 libs -->
-    <script type="module">
-      import process from 'process'
-      import { Buffer } from 'buffer'
-      import EventEmitter from 'events'
-
-      window.global = window
-      window.Buffer = Buffer
-      window.process = process
-      window.EventEmitter = EventEmitter
-    </script>
     <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "web3modal": "^1.9.5"
   },
   "devDependencies": {
+    "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
     "@preact/preset-vite": "^2.1.7",
     "@types/node": "^17.0.21",
     "@types/react": "^17.0.39",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, Plugin } from 'vite'
 import preact from '@preact/preset-vite'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import { visualizer } from 'rollup-plugin-visualizer'
+import GlobalsPolyfills from '@esbuild-plugins/node-globals-polyfill'
 
 export default defineConfig({
   plugins: [preact(), tsconfigPaths()],
@@ -12,6 +13,19 @@ export default defineConfig({
           gzipSize: true,
           brotliSize: true,
         }) as unknown as Plugin,
+      ],
+    },
+  },
+  optimizeDeps: {
+    esbuildOptions: {
+      define: {
+        global: 'globalThis',
+      },
+      plugins: [
+        GlobalsPolyfills({
+          process: true,
+          buffer: true,
+        }),
       ],
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1673,6 +1673,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild-plugins/node-globals-polyfill@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "@esbuild-plugins/node-globals-polyfill@npm:0.1.1"
+  peerDependencies:
+    esbuild: "*"
+  checksum: 68a41e2c377724e9cd46ca344ad219d289cc41a8b273d0d89bbc82bd90025b067b28234a865d8862a3f38c2a028ca4c93138dfca4e1e75e617efc314156c1ce0
+  languageName: node
+  linkType: hard
+
 "@eslint/eslintrc@npm:^1.2.0":
   version: 1.2.0
   resolution: "@eslint/eslintrc@npm:1.2.0"
@@ -14376,6 +14385,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "street-cred-frontend@workspace:."
   dependencies:
+    "@esbuild-plugins/node-globals-polyfill": ^0.1.1
     "@preact/preset-vite": ^2.1.7
     "@toruslabs/torus-embed": ^1.20.4
     "@types/node": ^17.0.21


### PR DESCRIPTION
- Actually it's better not to use the node.js inside the browser, but whole `web3.js` depends on many `noje.js` features, so we can't avoid it right now
