### PR TITLE
Fix error on create tree proof function

### DIFF
--- a/src/helpers/ExtendedERC721Contract.ts
+++ b/src/helpers/ExtendedERC721Contract.ts
@@ -39,7 +39,7 @@ export default class ExtendedERC721Contract {
     const events = await this.contract.queryFilter(eventsFilter)
     const ids = events
       .filter((event) => event.args.to.toLowerCase() === account.toLowerCase())
-      .map((id) => Number(id))
+      .map((event) => Number(event.args.tokenId))
     return ids
   }
 

--- a/src/helpers/createTreeProof.ts
+++ b/src/helpers/createTreeProof.ts
@@ -3,12 +3,11 @@ import StreetCredStore from 'stores/StreetCredStore'
 import WalletStore from 'stores/WalletStore'
 import poseidon from 'poseidon/poseidon.js'
 
-export default async function createTreeProof(contract?: string) {
-  if (!contract || !WalletStore.account) return
+export default async function createTreeProof(contractAddress?: string) {
   const ledger = await StreetCredStore.ledger
-  if (!ledger) return
-  const tokenId = await ledger[contract].getTokenId(WalletStore.account)
-  const addresses = await ledger[contract].getListOfOwners()
+  if (!ledger || !contractAddress || !WalletStore.account) return
+  const tokenId = await ledger[contractAddress].getTokenId(WalletStore.account)
+  const addresses = await ledger[contractAddress].getListOfOwners()
   if (!addresses || tokenId === undefined) return
 
   const tree = new IncrementalMerkleTree(poseidon, 20, BigInt(0), 2)


### PR DESCRIPTION
- add function to get one tokenID
- add function to get all user's tokenIDs
- fix errors in `createTreeProof` function