### PR TITLE
Add os inject to prevent error on creating proofs

### DIFF
--- a/src/helpers/checkNavigator.ts
+++ b/src/helpers/checkNavigator.ts
@@ -1,0 +1,10 @@
+export default function () {
+  if (typeof navigator === 'object' && navigator.hardwareConcurrency) return
+  // if there is no accessibility to navigator object or concurrency set it to default number
+  Object.defineProperties(window.navigator, {
+    hardwareConcurrency: {
+      value: 2,
+      writable: true,
+    },
+  })
+}

--- a/src/stores/ProofStore.ts
+++ b/src/stores/ProofStore.ts
@@ -7,6 +7,7 @@ import Proof from 'models/Proof'
 import WalletStore from 'stores/WalletStore'
 import buildBabyJub from 'circomlibjs/babyjub'
 import buildMimc7 from 'circomlibjs/mimc7'
+import checkNavigator from 'helpers/checkNavigator'
 import handleError from 'helpers/handleError'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -57,6 +58,8 @@ class ProofStore extends PersistableStore {
         pubKeyX: x,
         pubKeyY: y,
       }
+      // Check navigator availability
+      checkNavigator()
       // return
       proofStore.proofsCompleted.push({
         contract,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      os: 'rollup-plugin-node-polyfills/polyfills/os',
       stream: 'stream-browserify',
       https: 'agent-base',
       assert: 'assert-browserify',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
         }) as unknown as Plugin,
         nodePolyfills() as unknown as Plugin,
         inject({
+          os: 'os',
           assert: 'assert',
           process: 'process',
           Buffer: ['buffer', 'Buffer'],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,7 +18,6 @@ export default defineConfig({
         }) as unknown as Plugin,
         nodePolyfills() as unknown as Plugin,
         inject({
-          os: 'os',
           assert: 'assert',
           process: 'process',
           Buffer: ['buffer', 'Buffer'],
@@ -48,7 +47,6 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      os: 'rollup-plugin-node-polyfills/polyfills/os',
       stream: 'stream-browserify',
       https: 'agent-base',
       assert: 'assert-browserify',


### PR DESCRIPTION
- created function to check accessibility of `navigator` & `hardwareConcurrency`
- if `navigator` or  `hardwareConcurrency` is not available, set it to `2` because the WebKit build for iOS can return maximum of 2 CPUs
