### PR TITLE
removed $ from the email confirmation message

### DIFF
--- a/src/components/proofs/EmailProof.tsx
+++ b/src/components/proofs/EmailProof.tsx
@@ -118,7 +118,7 @@ export default function () {
             <BadgeText>
               {domain ? (
                 <>
-                  A token has been sent to ${email}. Copy the token and add it
+                  A token has been sent to {email}. Copy the token and add it
                   here to create zk proof. Or{' '}
                   <button
                     className={textDecoration('underline')}


### PR DESCRIPTION
## What
* Got rid of '$' in front of email in email confirmation message