### PR TITLE
fixed line height for mobile on landing page

### DIFF
--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -24,7 +24,9 @@ const headerText = (accent = false, extraLeading = false, xs = false) =>
     fontWeight('font-bold'),
     fontSize(xs ? 'text-2xl' : 'text-3xl', 'sm:text-4xl'),
     textColor(accent ? 'text-accent' : 'text-formal-accent'),
-    lineHeight(extraLeading ? 'leading-11' : 'leading-8')
+    extraLeading
+      ? lineHeight('leading-9', 'sm:leading-10', 'md:leading-11')
+      : lineHeight('leading-8')
   )
 export function HeaderText({
   accent,


### PR DESCRIPTION
## What
* Fixed the line height of the landing card on mobile screens
## Demo
[Old spacing](https://user-images.githubusercontent.com/26176104/176013272-41a821b8-3d5c-47b9-9774-8081e755dbd6.png)
[New spacing](https://user-images.githubusercontent.com/26176104/176015183-42dcc6c0-1841-490c-b5f5-c80a4f5ca28e.png)
