### PR TITLE
fixed text arc on privacy death

### DIFF
--- a/src/components/landing/PrivacyDeath.tsx
+++ b/src/components/landing/PrivacyDeath.tsx
@@ -29,7 +29,7 @@ export default function () {
   return (
     <div className={wrapperBox}>
       <div className={arcText}>
-        <ArcText text="Give me privacy or give me death •" />
+        <ArcText text="Give me privacy or give me death •" smallCircle />
       </div>
       <div className={eyeBoxMargin}>
         <EyeWhale />

--- a/src/icons/ArcText.tsx
+++ b/src/icons/ArcText.tsx
@@ -24,12 +24,13 @@ const svgBox = (mobile?: boolean) =>
 
 interface ArcTextProps {
   text: string
+  smallCircle?: boolean
 }
 
-export default function ({ text }: ArcTextProps) {
+export default function ({ text, smallCircle }: ArcTextProps) {
   const { xxs, sm, md } = useBreakpoints()
   const mobile = (xxs || sm) && !md
-  const radius = mobile ? 85 : 55
+  const radius = mobile ? 85 : smallCircle ? 110 : 55
 
   return (
     <svg


### PR DESCRIPTION
## What
* Reduced the size of the PrivacyDeath arctext
* Made arcText have the option to have one of two sizes (large circle, small circle)
## Demo
[Old text circle](https://user-images.githubusercontent.com/26176104/176022717-9a56ab7f-9af7-454f-9d1c-3df63f80909e.png)
[New text circle](https://user-images.githubusercontent.com/26176104/176022631-c1e34dcd-38b8-47f7-bb67-4c3d5ea6c540.png)
