### PR TITLE
fixed landing page horizontal scrolling, got rid of arctext overlap

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,28 @@
 import { Route, BrowserRouter as Router, Routes } from 'react-router-dom'
 import { ToastContainer } from 'react-toastify'
 import { lazy } from 'react'
-import { space } from 'classnames/tailwind'
 import Announcement from 'components/Announcement'
 import Footer from 'components/Footer'
 import LazyComponent from 'components/LazyComponent'
 import Navbar from 'components/navbar/Navbar'
 import Root from 'components/Root'
+import classnames, { overflow, space } from 'classnames/tailwind'
 
 const NotFound = lazy(() => import('pages/NotFound'))
 const OwnedBadge = lazy(() => import('pages/OwnedBadge'))
 const Landing = lazy(() => import('pages/Landing'))
 const Main = lazy(() => import('pages/Main'))
+const pageContainer = classnames(
+  space('space-y-6', 'sm:space-y-10'),
+  overflow('overflow-x-hidden')
+)
 
 export default function () {
   return (
     <Root>
       <Router>
         <Announcement redirectTo="/app" />
-        <div className={space('space-y-6', 'sm:space-y-10')}>
+        <div className={pageContainer}>
           <Navbar />
           <ToastContainer position="bottom-right" theme="dark" />
           <Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ const NotFound = lazy(() => import('pages/NotFound'))
 const OwnedBadge = lazy(() => import('pages/OwnedBadge'))
 const Landing = lazy(() => import('pages/Landing'))
 const Main = lazy(() => import('pages/Main'))
+
 const pageContainer = classnames(
   space('space-y-6', 'sm:space-y-10'),
   overflow('overflow-x-hidden')

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -32,7 +32,7 @@ const pageBox = classnames(
   flexDirection('flex-col'),
   alignItems('items-center')
 )
-const initialCardWrapper = classnames(margin('mt-10'))
+const initialCardWrapper = margin('mt-10')
 const identityCards = classnames(
   display('flex'),
   flexDirection('flex-row'),

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -32,6 +32,7 @@ const pageBox = classnames(
   flexDirection('flex-col'),
   alignItems('items-center')
 )
+const initialCardWrapper = classnames(margin('mt-10'))
 const identityCards = classnames(
   display('flex'),
   flexDirection('flex-row'),
@@ -81,7 +82,9 @@ export default function () {
 
   return (
     <div className={pageBox}>
-      <InitialCard />
+      <div className={initialCardWrapper}>
+        <InitialCard />
+      </div>
       <div className={topBlockWrapper}>
         <ScrollDownButton />
         <div className={topConnectorsWrapper}>


### PR DESCRIPTION
## What
* Got rid of horizontal scrolling issue on mobile phones on the landing page
* Fixed the arc text overlap with the opaque navbar on the landing page by adding a top margin of 10 on the initial card
## Demo
[Old](https://user-images.githubusercontent.com/26176104/176805032-2f7a8a9a-a1b7-4043-8a8b-282e1ce00a41.png)
[New](https://user-images.githubusercontent.com/26176104/176804920-8a76f71a-c401-437b-ad34-00eb5b14420b.png)
