### PR TITLE
fixed the tilting letters in arctext when letters increase in size

### DIFF
--- a/src/icons/ArcText.tsx
+++ b/src/icons/ArcText.tsx
@@ -3,6 +3,7 @@ import classnames, {
   fontSize,
   fontWeight,
   height,
+  letterSpacing,
   margin,
   padding,
   textTransform,
@@ -13,7 +14,8 @@ const textStyle = classnames(
   fill('fill-secondary'),
   textTransform('uppercase'),
   fontWeight('font-semibold'),
-  fontSize('text-3xl')
+  fontSize('text-3xl'),
+  letterSpacing('tracking-widest', 'md:!tracking-normal')
 )
 const svgBox = (mobile?: boolean) =>
   classnames(


### PR DESCRIPTION
## What
* Fixed the arctext issue where letters would tilt if the textsize got too big with increased text spacing
## Demo (on top of #321 changes)
[Old top spinner](https://user-images.githubusercontent.com/26176104/177224376-7b22ccf7-bc66-4835-84fc-18d2fc387d82.png)
[New top spinner](https://user-images.githubusercontent.com/26176104/177225175-338fda2c-dbba-49de-bac3-010a0884e912.png)
[New top spinner with #321 changes](https://user-images.githubusercontent.com/26176104/177224622-7c2f8de0-23ad-45b9-8923-2c0b6a168de9.png)

[Old footer spinner](https://user-images.githubusercontent.com/26176104/177224481-daa0ceef-e1af-4ee6-92b4-3bd7e98efbd1.png)
[New footer spinner](https://user-images.githubusercontent.com/26176104/177225199-72158c86-01a0-4771-b068-eaf437613bf5.png)
[New footer spinner with #321 changes](https://user-images.githubusercontent.com/26176104/177224598-3f1845fa-3be6-421f-b627-f3e122f54a5a.png)

## Testing
* All common portrait and landscape screensize ratios (16:9, 4:3, 3:2 at all of our tailwindcss breakpoints)

## Blocks 
* #321 from merging into main