### PR TITLE
Fix Link font size and add truncate if no ens

### DIFF
--- a/src/components/EnsAddress.tsx
+++ b/src/components/EnsAddress.tsx
@@ -20,7 +20,7 @@ function EnsAddressSuspended({
     <>
       {truncate
         ? truncateMiddleIfNeeded(ensName || address, 17)
-        : ensName || address}
+        : ensName || truncateMiddleIfNeeded(address, 25)}
     </>
   )
 }

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -180,6 +180,7 @@ const linkText = (
       gradientFrom && gradientTo ? 'bg-gradient-to-r' : undefined
     ),
     backgroundClip(gradientFrom && gradientTo ? 'bg-clip-text' : undefined),
+    fontSize('text-sm', 'tiny:text-base'),
     gradientColorStops(gradientFrom, gradientTo),
     fontWeight(bold ? 'font-bold' : 'font-normal')
   )


### PR DESCRIPTION
- made link font size smaller on tiny screens
- add truncate if no ens address on large screens
