### PR TITLE
Hide x overflow inside scroll component

### DIFF
--- a/src/components/Scrollbar.tsx
+++ b/src/components/Scrollbar.tsx
@@ -5,7 +5,7 @@ import useHasWebkit from 'hooks/useHasWebkit'
 import useIsOverflow from 'hooks/useIsOverflow'
 
 const wrapperStyles = classnames(
-  overflow('overflow-y-auto'),
+  overflow('overflow-y-auto', 'overflow-x-hidden'),
   position('relative')
 )
 


### PR DESCRIPTION
- Sometimes there is a scroll-x appears, you can't use it, so it's better to hide it (probably browser computates something wrong and shows scrollbar-gutter)
