### PR TITLE
Added margins for hint cards where needed

### DIFF
--- a/src/components/badges/HintCard.tsx
+++ b/src/components/badges/HintCard.tsx
@@ -8,17 +8,19 @@ import classnames, {
   flexDirection,
   fontSize,
   lineHeight,
+  margin,
   padding,
   space,
 } from 'classnames/tailwind'
 
-const container = (small?: boolean) =>
+const container = (small?: boolean, marginY?: boolean) =>
   classnames(
     display('flex'),
     flexDirection('flex-col'),
     borderRadius('rounded-lg'),
     backgroundColor('bg-primary-background'),
     padding('px-4', small ? 'py-2' : 'py-4'),
+    margin(marginY ? 'my-4' : undefined),
     space('space-y-4'),
     fontSize('text-sm'),
     lineHeight('leading-6')
@@ -27,12 +29,14 @@ export default function ({
   children,
   text,
   small,
+  marginY = true,
 }: ChildrenProp & {
   small?: boolean
   text?: ComponentChildren
+  marginY?: boolean
 }) {
   return (
-    <div className={container(small)}>
+    <div className={container(small, marginY)}>
       {text && <BadgeText>{text}</BadgeText>}
       {children}
     </div>

--- a/src/components/proofs/ERC721ProofSection.tsx
+++ b/src/components/proofs/ERC721ProofSection.tsx
@@ -38,7 +38,7 @@ export function ERC721ProofSection({
         />
       )}
       {nothingToGenerateMainnet && (
-        <HintCard small>
+        <HintCard small marginY={false}>
           <HintText bold center>
             No NFTs to proof
           </HintText>
@@ -59,7 +59,7 @@ export default function ERC721ProofSectionSuspended({
     <Suspense
       fallback={
         <ProofSection title={<BodyText>{network} NFTs</BodyText>}>
-          <HintCard small>
+          <HintCard small marginY={false}>
             <HintText bold center>
               Loading...
             </HintText>


### PR DESCRIPTION
- We can't use `space-y` in wrapping `<Card />` component, because it will break the `<Fade />` spacing for scrollbar

![image](https://user-images.githubusercontent.com/49658988/178670152-06cf8653-d088-4c52-8c32-c7a0fe347752.png)
![image](https://user-images.githubusercontent.com/49658988/178670184-19b4e336-448c-4e6c-bd76-4efd07f3cb75.png)
