### PR TITLE
Add hyphens to badge title & fix padding for several spans

### DIFF
--- a/src/components/ContractName.tsx
+++ b/src/components/ContractName.tsx
@@ -9,7 +9,6 @@ import classnames, {
   display,
   flexWrap,
   minWidth,
-  padding,
   wordBreak,
 } from 'classnames/tailwind'
 import truncateMiddleIfNeeded from 'helpers/truncateMiddleIfNeeded'
@@ -18,8 +17,7 @@ const addressText = wordBreak('break-all')
 const badgeNameWrapper = classnames(
   minWidth('min-w-fit'),
   display('inline-flex'),
-  flexWrap('flex-wrap'),
-  padding('pr-2')
+  flexWrap('flex-wrap')
 )
 
 interface ContractNameProps {

--- a/src/components/badges/BadgeTitle.tsx
+++ b/src/components/badges/BadgeTitle.tsx
@@ -8,7 +8,9 @@ import getEtherscanAddressUrl from 'helpers/getEtherscanAddressUrl'
 
 function ProofName({ badge }: { badge: BaseProof }) {
   if (badge instanceof ERC721Proof)
-    return <ContractName address={badge.contract} network={Network.Goerli} />
+    return (
+      <ContractName hyphens address={badge.contract} network={Network.Goerli} />
+    )
   if (badge instanceof EmailProof) return <>@{badge.domain}</>
   return <>Unknown</>
 }
@@ -26,6 +28,7 @@ export default function ({
         url={getEtherscanAddressUrl(derivativeAddress, Network.Goerli)}
       >
         <ContractName
+          hyphens
           address={derivativeAddress}
           clearType
           network={Network.Goerli}

--- a/src/index.css
+++ b/src/index.css
@@ -36,6 +36,9 @@ body {
   hyphens: auto;
   line-height: initial;
 }
+.hyphensAuto > span + span {
+  padding-left: 6px;
+}
 /* Grid for mobiles */
 @media screen and (max-width: 600px) {
   body {


### PR DESCRIPTION
- added `hyphens` to badge title
- fixed padding when several spans are set
