### PR TITLE
replaced user signatures r2 and s2 with 64-bit random numbers

### DIFF
--- a/src/helpers/ERC721Proof.ts
+++ b/src/helpers/ERC721Proof.ts
@@ -106,10 +106,11 @@ export default class ERC721Proof
   async generateInputs(
     ownershipSignature: Signature,
     balanceSignature: BalanceSignature,
-    nullifierSignature: string,
     eddsaPublicKey: PublicKey
   ) {
-    const { r: r2, s: s2 } = utils.splitSignature(nullifierSignature)
+    const randomNumbersArray = crypto.getRandomValues(new BigUint64Array(2))
+    const r2 = randomNumbersArray[0].toString()
+    const s2 = randomNumbersArray[1].toString()
     const addressInputs = await this.inputsForSignature(
       eddsaPublicKey,
       ownershipSignature,
@@ -131,13 +132,11 @@ export default class ERC721Proof
   async build(
     ownershipSignature: Signature,
     balanceSignature: BalanceSignature,
-    nullifierSignature: string,
     eddsaPublicKey: PublicKey
   ) {
     const inputs = await this.generateInputs(
       ownershipSignature,
       balanceSignature,
-      nullifierSignature,
       eddsaPublicKey
     )
     this.result = await snarkjs.groth16.fullProve(

--- a/src/helpers/ERC721Proof.ts
+++ b/src/helpers/ERC721Proof.ts
@@ -108,9 +108,7 @@ export default class ERC721Proof
     balanceSignature: BalanceSignature,
     eddsaPublicKey: PublicKey
   ) {
-    const randomNumbersArray = crypto.getRandomValues(new BigUint64Array(2))
-    const r2 = randomNumbersArray[0].toString()
-    const s2 = randomNumbersArray[1].toString()
+    const [r2, s2] = crypto.getRandomValues(new BigUint64Array(2))
     const addressInputs = await this.inputsForSignature(
       eddsaPublicKey,
       ownershipSignature,

--- a/src/helpers/EmailProof.ts
+++ b/src/helpers/EmailProof.ts
@@ -67,9 +67,7 @@ export default class EmailProof extends BaseProof implements EmailProofSchema {
       utils.toUtf8Bytes(domain),
       maxDomainLength
     )
-    const randomNumbersArray = crypto.getRandomValues(new BigUint64Array(2))
-    const r2 = randomNumbersArray[0].toString()
-    const s2 = randomNumbersArray[1].toString()
+    const [r2, s2] = crypto.getRandomValues(new BigUint64Array(2))
     return {
       message: Array.from(messageUInt8),
       pubKeyX: eddsaPublicKey.x,

--- a/src/helpers/unpackECDSASignature.ts
+++ b/src/helpers/unpackECDSASignature.ts
@@ -1,6 +1,0 @@
-import { utils } from 'ethers'
-
-export default function (signature: string) {
-  const { r: r2, s: s2 } = utils.splitSignature(signature)
-  return { r2, s2 }
-}

--- a/src/stores/ProofStore.ts
+++ b/src/stores/ProofStore.ts
@@ -84,14 +84,11 @@ class ProofStore extends PersistableStore {
     try {
       // Get public key
       const eddsaPublicKey = await getEddsaPublicKey()
-      // Get nullifier signature
-      const nullifierMessage = getNullifierMessage()
-      const nullifierSignature = await WalletStore.signMessage(nullifierMessage)
       // Check navigator availability
       checkNavigator()
       // Create proof
       const newEmailProof = new EmailProof(domain)
-      await newEmailProof.build(signature, eddsaPublicKey, nullifierSignature)
+      await newEmailProof.build(signature, eddsaPublicKey)
       this.proofsCompleted.push(newEmailProof)
       return newEmailProof
     } catch (e) {
@@ -128,7 +125,6 @@ class ProofStore extends PersistableStore {
       await newERC721Proof.build(
         ownershipSignature,
         balanceSignature,
-        nullifierSignature,
         eddsaPublicKey
       )
       this.proofsCompleted.push(newERC721Proof)


### PR DESCRIPTION
## What 
* Replaced `r2` and `s2` in ERC721Proof.ts with random numbers as opposed to user signatures. 