### PR TITLE
Current minting will display loading, while others will be blocked

### DIFF
--- a/src/components/badges/BadgeBlock.tsx
+++ b/src/components/badges/BadgeBlock.tsx
@@ -24,13 +24,13 @@ function Badge({
   onMintFailed?: (minted?: MintedToken[]) => void
 }) {
   const { account, mintLoading } = useSnapshot(WalletStore)
-  const [localLoading, setLocalLoading] = useState(false)
+  const [loading, setLoading] = useState(false)
 
   const isEmailProof = proof instanceof EmailProof
 
   const checkProofAndMint = async () => {
     WalletStore.mintLoading = true
-    setLocalLoading(true)
+    setLoading(true)
     try {
       if (!account) throw new Error('No account found')
       if (!proof?.result) throw new Error('No proof found')
@@ -57,7 +57,7 @@ function Badge({
         handleError(error)
       }
     } finally {
-      setLocalLoading(false)
+      setLoading(false)
       WalletStore.mintLoading = false
     }
   }
@@ -70,7 +70,7 @@ function Badge({
         <Button
           small
           type="primary"
-          loading={localLoading}
+          loading={loading}
           disabled={!proof || mintLoading}
           onClick={checkProofAndMint}
         >

--- a/src/components/badges/BadgeBlock.tsx
+++ b/src/components/badges/BadgeBlock.tsx
@@ -1,6 +1,6 @@
 import { GoerliContractsStore } from 'stores/ContractsStore'
 import { useSnapshot } from 'valtio'
-import { useState } from 'react'
+import { useState } from 'preact/hooks'
 import BadgeCard from 'components/badges/BadgeCard'
 import BadgeTitle from 'components/badges/BadgeTitle'
 import BadgeWrapper from 'components/badges/BadgeWrapper'
@@ -23,14 +23,14 @@ function Badge({
   onMinted?: (minted?: MintedToken[]) => void
   onMintFailed?: (minted?: MintedToken[]) => void
 }) {
-  const { account } = useSnapshot(WalletStore)
-  const [loading, setLoading] = useState(false)
+  const { account, mintLoading } = useSnapshot(WalletStore)
+  const [localLoading, setLocalLoading] = useState(false)
 
   const isEmailProof = proof instanceof EmailProof
 
   const checkProofAndMint = async () => {
-    setLoading(true)
-
+    WalletStore.mintLoading = true
+    setLocalLoading(true)
     try {
       if (!account) throw new Error('No account found')
       if (!proof?.result) throw new Error('No proof found')
@@ -57,7 +57,8 @@ function Badge({
         handleError(error)
       }
     } finally {
-      setLoading(false)
+      setLocalLoading(false)
+      WalletStore.mintLoading = false
     }
   }
 
@@ -69,8 +70,8 @@ function Badge({
         <Button
           small
           type="primary"
-          loading={loading}
-          disabled={!proof}
+          loading={localLoading}
+          disabled={!proof || mintLoading}
           onClick={checkProofAndMint}
         >
           {proof ? 'Mint badge' : 'Minted!'}

--- a/src/stores/WalletStore.ts
+++ b/src/stores/WalletStore.ts
@@ -23,6 +23,7 @@ let provider: Web3Provider
 class WalletStore extends PersistableStore {
   account?: string
   walletLoading = false
+  mintLoading = false
   needNetworkChange = false
   walletsToNotifiedOfBeingDoxxed = {} as {
     [address: string]: boolean
@@ -75,7 +76,6 @@ class WalletStore extends PersistableStore {
 
   async mintDerivative(proof: BaseProof) {
     if (!provider) throw new Error('No provider found')
-    if (!this.account) throw new Error('No account found')
 
     const gsnProvider = await relayProvider(provider)
 


### PR DESCRIPTION
- Added `mintLoading` to `WalletStore` to share state across button
- Added `[localLoading]` to mint button to display loading state only for current minting proccess