### PR TITLE
Added tweet and copy link CTAs without formatting

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -145,6 +145,7 @@ interface ButtonProps {
   withArrow?: boolean
   gradientFont?: boolean
   loadingOverflow?: boolean
+  url?: string
 }
 
 type ButtonType = 'primary' | 'secondary' | 'tertiary'
@@ -160,6 +161,7 @@ export default function ({
   children,
   gradientFont,
   loadingOverflow,
+  url,
   ...rest
 }: Omit<React.HTMLAttributes<HTMLButtonElement>, 'loading'> & ButtonProps) {
   const showContent = !loadingOverflow || !loading
@@ -174,13 +176,16 @@ export default function ({
         type,
         small,
       })}
+      onClick={() => {
+        if (url) window.open(url, '_blank')
+      }}
       disabled={!available}
       {...rest}
     >
       {loading && <Loading small={small} />}
       {showContent && (
         <>
-          {typeof children === 'string' && gradientFont ? (
+          {gradientFont ? (
             <span className={textGradient(available)}>{children}</span>
           ) : (
             <div>{children}</div>

--- a/src/components/owned/OwnerInfo.tsx
+++ b/src/components/owned/OwnerInfo.tsx
@@ -9,6 +9,7 @@ import ExternalLink from 'components/ExternalLink'
 import HorizontalRule from 'components/HorizontalRule'
 import Network from 'models/Network'
 import OwnedBadgeAddress from 'components/owned/OwnedBadgeAddress'
+import ShareCTAButtons from 'components/owned/ShareCTAButtons'
 import Smile from 'icons/Smile'
 import classnames, {
   alignItems,
@@ -77,6 +78,7 @@ function BadgeContent({ badge }: { badge: BaseBadgeContract }) {
         This is a zkNFT derivative of an email. It means this person has been
         verified own a ‘
         <AccentText color="text-secondary">{badge.domain}</AccentText>‘ email.
+        <ShareCTAButtons />
       </BodyText>
     )
   }
@@ -97,6 +99,7 @@ function BadgeContent({ badge }: { badge: BaseBadgeContract }) {
           </AccentText>
         </ExternalLink>
         ‘ {badge.network[0].toUpperCase() + badge.network.slice(1)} NFT.
+        <ShareCTAButtons />
       </BodyText>
     )
   }

--- a/src/components/owned/ShareCTAButtons.tsx
+++ b/src/components/owned/ShareCTAButtons.tsx
@@ -1,0 +1,73 @@
+import { toast } from 'react-toastify'
+import { useLocation } from 'react-router-dom'
+import Button from 'components/Button'
+import LinkChain from 'icons/LinkChain'
+import Twitter from 'icons/Twitter'
+import classnames, {
+  alignItems,
+  display,
+  flexDirection,
+  gap,
+  margin,
+  space,
+  textColor,
+} from 'classnames/tailwind'
+
+const buttonContentWrapper = classnames(
+  display('flex'),
+  flexDirection('flex-row'),
+  gap('gap-x-3'),
+  textColor('text-inherit'),
+  alignItems('items-center')
+)
+
+const buttonWrapper = classnames(
+  display('flex'),
+  flexDirection('flex-row'),
+  space('space-x-3'),
+  margin('my-4')
+)
+
+async function copy(pathname: string) {
+  await navigator.clipboard.writeText('sealcred.xyz' + pathname)
+}
+
+export default function () {
+  const { pathname } = useLocation()
+
+  return (
+    <div className={buttonWrapper}>
+      <Button
+        gradientFont
+        type="secondary"
+        small
+        url={`http://twitter.com/share?url=${encodeURIComponent(
+          `I minted a zk Badge using SealCred. Check out this privacy-preserving protocol at sealcred.xyz`
+        )}`}
+      >
+        <div className={buttonContentWrapper}>
+          <div className="text-white">
+            <Twitter />
+          </div>
+          Tweet
+        </div>
+      </Button>
+      <Button
+        gradientFont
+        type="secondary"
+        small
+        onClick={async () => {
+          await copy(pathname)
+          toast('Link copied 👍')
+        }}
+      >
+        <div className={buttonContentWrapper}>
+          <div className="text-white">
+            <LinkChain />
+          </div>
+          Copy link
+        </div>
+      </Button>
+    </div>
+  )
+}

--- a/src/icons/LinkChain.tsx
+++ b/src/icons/LinkChain.tsx
@@ -1,0 +1,26 @@
+export default function () {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M18.3137 12.3137L20.0815 10.5459C21.8388 8.78856 21.8388 5.93932 20.0815 4.18196V4.18196C18.3241 2.4246 15.4749 2.4246 13.7175 4.18196L10.182 7.71749C8.42462 9.47485 8.42462 12.3241 10.182 14.0815V14.0815L10.5 14.3995"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M5.94975 11.9497L4.18198 13.7175C2.42462 15.4749 2.42462 18.3241 4.18198 20.0815V20.0815C5.93934 21.8388 8.78858 21.8388 10.5459 20.0815L14.0815 16.5459C15.8388 14.7886 15.8388 11.9393 14.0815 10.182V10.182L13.8995 10"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  )
+}


### PR DESCRIPTION
## What 
* Added a Share to Twitter and a Copy Link CTA Button on OwnerInfo.tsx
* `yarn preview` passes

## Demo
[Toastify notification for `Copy Link`](https://user-images.githubusercontent.com/26176104/183751273-91899ee0-c19c-47a7-8450-1999b1b47200.png)
[New CTA Button Responsiveness Video](https://user-images.githubusercontent.com/26176104/183750853-d8aa3f1d-c5ad-4b46-8094-f9ec038112f3.webm)

