### PR TITLE
got rid of scroll due to announcement

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,10 +35,12 @@ export default function () {
   return (
     <Root>
       <Router>
-        <Announcement redirectTo="/email" />
         <ToastContainer position="bottom-right" theme="dark" />
         <div className={pageContainer}>
-          <Navbar />
+          <div>
+            <Announcement redirectTo="/email" />
+            <Navbar />
+          </div>
           <ScrollToTop>
             <div className={space('space-y-4')}>
               <Routes>

--- a/src/components/LazyComponent.tsx
+++ b/src/components/LazyComponent.tsx
@@ -1,13 +1,12 @@
 import { JSX } from 'preact'
 import { Suspense } from 'react'
-import { minHeight } from 'classnames/tailwind'
 import Loading from 'icons/Loading'
 
 export default function ({ lazyImported }: { lazyImported: JSX.Element }) {
   return (
     <Suspense
       fallback={
-        <div className={minHeight('min-h-screen')}>
+        <div>
           <Loading screenCentre />
         </div>
       }


### PR DESCRIPTION
## What
* Removed scroll due to announcement even if content height is less than screen height
## Demo
[Announcement with no scroll](https://user-images.githubusercontent.com/26176104/184009964-3fb94165-c999-41a6-84f7-c0366206797d.png)
[Old announcement with scroll](https://user-images.githubusercontent.com/26176104/184013324-3435481c-0fd4-456f-b086-7edc2c7fab34.png)

