### PR TITLE
made badge grid hold 3 badges per row

### DIFF
--- a/src/components/badges/BadgeSection.tsx
+++ b/src/components/badges/BadgeSection.tsx
@@ -15,7 +15,7 @@ const badgesList = classnames(
   display('grid'),
   gap('gap-2'),
   gridAutoRows('auto-rows-auto'),
-  gridTemplateColumns('grid-cols-1', 'lg:grid-cols-2')
+  gridTemplateColumns('grid-cols-1', 'lg:grid-cols-3')
 )
 
 export default function ({


### PR DESCRIPTION
## Changes
* Made rows in BadgeCard display 3 badges per row instead of 2

## Notes
* Merging into `add-ux-sizing` because the change doesn't make sense in the current design
[Demo](https://user-images.githubusercontent.com/26176104/186775149-5b7e796c-a8cc-46f7-b419-6fb797f7a8f2.png)
